### PR TITLE
Allow disabling response from post endpoint

### DIFF
--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -18,9 +18,9 @@ export default function (req, res, next) {
 		.then(subscribeToMailingList)
 		.then(silentlySubmitTrackingEvent)
 		.then(sendEmailAfter5am)
-		.then(render)
+		.then(() => send('SUBSCRIPTION_SUCCESSFUL'))
 		.catch(error => {
-			if (error.reason) return res.status(200).send(error.reason);
+			if (error.reason) return send(error.reason);
 			next(new Error(error));
 		});
 
@@ -71,7 +71,7 @@ export default function (req, res, next) {
 		return Promise.resolve();
 	}
 
-	function render (response) {
-		res.status(200).send('SUBSCRIPTION_SUCCESSFUL');
+	function send(response) {
+		res.status(200).send(response);
 	}
 }

--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -72,6 +72,10 @@ export default function (req, res, next) {
 	}
 
 	function send(response) {
-		res.status(200).send(response);
+		if(req.newsletterSignupPostNoResponse) {
+			res.locals.newsletterSignupStatus = response;
+		} else {
+			res.status(200).send(response);
+		}
 	}
 }


### PR DESCRIPTION
In Instant Articles for some reason submitting the form via JS and fetch isn't working. We need to do a regular form submission and render a template instead of just sending back the status code.
