### PR TITLE
Allow a customised mailingList name and source from req.body

### DIFF
--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -5,11 +5,11 @@ import logger from '@financial-times/n-logger';
 
 export default function (req, res, next) {
 
-	const mailingList = 'next-article';
+	const mailingList = req.body && req.body.mailingList ? req.body.mailingList : 'light-signup';
 	const spoor = new SpoorClient({
-		source: 'next-signup',
+		source: req.body && req.body.source ? req.body.source : null,
 		category: 'light-signup',
-		req,
+		req
 	});
 
 	logger.info(req.body);

--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -14,7 +14,7 @@ export default function (req, res, next) {
 
 	logger.info(req.body);
 
-	validateEmailAddress()
+	validateRequest()
 		.then(subscribeToMailingList)
 		.then(silentlySubmitTrackingEvent)
 		.then(sendEmailAfter5am)
@@ -24,11 +24,11 @@ export default function (req, res, next) {
 			next(new Error(error));
 		});
 
-	function validateEmailAddress () {
+	function validateRequest () {
 		return new Promise(function (resolve, reject) {
-			if (req.body && req.body.email) {
+			if (req.body && req.body.email && req.body.source) {
 
-				if (/(.+)@(.+)/.test(req.body.email)) {
+				if (validateEmailAddress(req.body.email)) {
 					resolve({});
 				} else {
 					reject({ reason: 'INVALID_EMAIL' });
@@ -38,6 +38,10 @@ export default function (req, res, next) {
 				reject({reason: 'INVALID_REQUEST'});
 			}
 		});
+	}
+
+	function validateEmailAddress (email) {
+		return /(.+)@(.+)/.test(email);
 	}
 
 	function silentlySubmitTrackingEvent () {


### PR DESCRIPTION
Allow passing of custom `mailingList` name and `source` from the form values via `req.body`.

Do we want / are we happy with the proposed fallback values?
`mailingList: light-signup` (~~next-article~~)
`source: null` (~~next-signup~~)

Alternatively do we want to enforce the setting of these values and return an error if not set?
