### PR TITLE
Change how we track the source of the signup form

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "description": "",
   "dependencies": {
     "@financial-times/n-logger": "^5.3.0",
-    "@financial-times/n-spoor-client": "^1.0.0",
+    "@financial-times/n-spoor-client": "^1.1.0",
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
     "node-fetch": "^1.5.1"

--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -7,8 +7,9 @@ export default function (req, res, next) {
 
 	const mailingList = req.body && req.body.mailingList ? req.body.mailingList : 'light-signup';
 	const spoor = new SpoorClient({
-		source: req.body && req.body.source ? req.body.source : null,
+		source: 'newsletter-signup',
 		category: 'light-signup',
+		product: req.body && req.body.source ? req.body.source : null,
 		req
 	});
 


### PR DESCRIPTION
The spoor client source should be consistent and used as a marker
of what "app/module/client" events are coming from.

The `context.product` should be either "next", "ft.com" or another
value such as "facebook-ia" etc. The spoor client will default to
"next". see (https://github.com/Financial-Times/n-spoor-client/commit/8dd4a094aeb4f54da930f95c42eb686dafaa7b81)
