### PR TITLE
Pass explicit cookies and ua headers to n-spoor-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "description": "",
   "dependencies": {
     "@financial-times/n-logger": "^5.3.0",
-    "@financial-times/n-spoor-client": "^1.1.0",
+    "@financial-times/spoor-client": "^2.0.0",
     "body-parser": "^1.15.0",
     "express": "^4.13.4",
     "node-fetch": "^1.5.1"

--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -1,6 +1,6 @@
 import {subscribe} from '../api/anon-email-lists';
 import {send} from '../api/anon-email-svc';
-import SpoorClient from '@financial-times/n-spoor-client';
+import SpoorClient from '@financial-times/spoor-client';
 import logger from '@financial-times/n-logger';
 
 export default function (req, res, next) {

--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -6,11 +6,15 @@ import logger from '@financial-times/n-logger';
 export default function (req, res, next) {
 
 	const mailingList = req.body && req.body.mailingList ? req.body.mailingList : 'light-signup';
+	const cookies = req.get('cookie') || req.get('ft-cookie-original');
+	const ua = req.get('user-agent');
+
 	const spoor = new SpoorClient({
 		source: 'newsletter-signup',
 		category: 'light-signup',
 		product: req.body && req.body.source ? req.body.source : null,
-		req
+		cookies,
+		ua,
 	});
 
 	logger.info(req.body);
@@ -63,7 +67,7 @@ export default function (req, res, next) {
 		return subscribe({
 			email: req.body.email,
 			mailingList: mailingList,
-			deviceId: extractDeviceId(req.get('ft-cookie-original'))
+			deviceId: extractDeviceId(cookies),
 		})
 		.catch(error => {
 			return Promise.reject(error);


### PR DESCRIPTION
Pass explicit cookies and ua headers to `n-spoor-client`, as `ft-cookie-original` is not set outside Next ecosystem.
