### PR TITLE
Ability to send 'following' data

### DIFF
--- a/src/api/anon-email-lists.js
+++ b/src/api/anon-email-lists.js
@@ -33,17 +33,22 @@ function logSubscription({deviceId, email}) {
 	})).catch(e => logger.warn(e));
 }
 
-export function subscribe({email, mailingList, deviceId, topics}={}) {
-	logger.info(`anon-email-api about to subscribe user (device ${deviceId}) to ${mailingList} with topics: ${topics}`);
+export function subscribe({ email, mailingList, deviceId, topics, following } = { }) {
+	logger.info('anon-email-api about to subscribe user', { device_id: deviceId, mailing_list: mailingList, topics, following });
 
 	let status;
+	const data = {
+		mailingListName: mailingList,
+		userEmail: email,
+		deviceId
+	};
+	if (following) {
+		data.following = following;
+	} else {
+		data.topics = topics;
+	}
 
-	return call('/mailingList/subscribe', {
-		'mailingListName': mailingList,
-		'deviceId': deviceId,
-		'userEmail': email,
-		'topics': topics
-	})
+	return call('/mailingList/subscribe', data)
 	.then(response => {
 		logger.info(`anon-email-api response ${response.status}`);
 

--- a/src/api/anon-email-lists.js
+++ b/src/api/anon-email-lists.js
@@ -25,7 +25,7 @@ function logSubscription({deviceId, email}) {
 	// don't wait on this promise, log in the background
 	call(`/user/${email}`, null, 'GET').then(r => r.json().then(json => {
 		if(r.ok) {
-			logger.info(`anon-email-api subscribed user (device ${deviceId}) as ${json.uuid}`)
+			logger.info(`anon-email-api subscribed user as ${json.uuid}`, { deviceId })
 		} else {
 			const err = new Error(JSON.stringify(json));
 			err.response = r;
@@ -34,8 +34,6 @@ function logSubscription({deviceId, email}) {
 }
 
 export function subscribe({ email, mailingList, deviceId, topics, following } = { }) {
-	logger.info('anon-email-api about to subscribe user', { device_id: deviceId, mailing_list: mailingList, topics, following });
-
 	let status;
 	const data = {
 		mailingListName: mailingList,
@@ -47,6 +45,7 @@ export function subscribe({ email, mailingList, deviceId, topics, following } = 
 	} else {
 		data.topics = topics;
 	}
+	logger.info('anon-email-api about to subscribe user', data);
 
 	return call('/mailingList/subscribe', data)
 	.then(response => {

--- a/src/api/anon-email-lists.js
+++ b/src/api/anon-email-lists.js
@@ -45,7 +45,10 @@ export function subscribe({ email, mailingList, deviceId, topics, following } = 
 	} else {
 		data.topics = topics;
 	}
-	logger.info('anon-email-api about to subscribe user', data);
+	// remove sensitive data when logging
+	const loggingData = Object.assign({}, data);
+	delete loggingData.userEmail;
+	logger.info('anon-email-api about to subscribe user', loggingData);
 
 	return call('/mailingList/subscribe', data)
 	.then(response => {

--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -8,6 +8,7 @@ export default function (req, res, next) {
 	const product = req.body && (req.body.product || req.body.source) || null;
 	const mailingList = req.body && req.body.mailingList ? req.body.mailingList : 'light-signup';
 	const topics = req.body && req.body.topics ? req.body.topics : 'default';
+	const following = (req.body && req.body.following) || null;
 	const articleUuid = req.body && req.body.articleUuid ? req.body.articleUuid : null;
 	const cookies = (req.body && req.body.cookie) || req.get('cookie') || req.get('ft-cookie-original');
 	const ua = (req.body && req.body.ua) || req.get('user-agent');
@@ -63,7 +64,8 @@ export default function (req, res, next) {
 			action: 'subscribed',
 			context: {
 				list: mailingList,
-				topics: topics,
+				topics,
+				following,
 				content: {
 					uuid: articleUuid,
 				}
@@ -79,8 +81,9 @@ export default function (req, res, next) {
 	function subscribeToMailingList () {
 		return subscribe({
 			email: req.body.email,
-			mailingList: mailingList,
-			topics: topics,
+			mailingList,
+			topics,
+			following,
 			deviceId,
 		})
 		.catch(error => {

--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -60,17 +60,18 @@ export default function (req, res, next) {
 	}
 
 	function silentlySubmitTrackingEvent () {
-		spoor.submit({
-			action: 'subscribed',
-			context: {
-				list: mailingList,
-				topics,
-				following,
-				content: {
-					uuid: articleUuid,
-				}
+		const context = {
+			list: mailingList,
+			content: {
+				uuid: articleUuid,
 			}
-		});
+		};
+		if (following) {
+			context.following = following;
+		} else {
+			context.topics = topics;
+		}
+		spoor.submit({ action: 'subscribed', context });
 	}
 
 	function extractDeviceId (cookie) {
@@ -98,7 +99,7 @@ export default function (req, res, next) {
 	}
 
 	function sendStatus(response) {
-		logger.info(`final status for ${deviceId} is ${response}`);
+		logger.info(`final status is ${response}`, { deviceId });
 
 		if(req.newsletterSignupPostNoResponse) {
 			res.locals.newsletterSignupStatus = response;


### PR DESCRIPTION
Slightly more verbose than it needs to be as keeping it backwards compatible by giving `topics` a default of `default`

If both `topics` and `following` is sent, only `following` is sent (make sense?)
